### PR TITLE
Adding Custom Keywords Option To SEO Handling

### DIFF
--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -10,7 +10,7 @@ import PropTypes from "prop-types"
 import Helmet from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, keywords}) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -67,7 +67,13 @@ function SEO({ description, lang, meta, title }) {
           name: `twitter:description`,
           content: metaDescription,
         },
-      ].concat(meta)}
+      ].concat(
+        (keywords.length == 0) ? [] : 
+        {
+          name:  `keywords`,
+          content: keywords.join(' '),
+        }
+      ).concat(meta)}
     />
   )
 }
@@ -75,6 +81,7 @@ function SEO({ description, lang, meta, title }) {
 SEO.defaultProps = {
   lang: `en`,
   meta: [],
+  keywords: [],
   description: ``,
 }
 
@@ -82,6 +89,7 @@ SEO.propTypes = {
   description: PropTypes.string,
   lang: PropTypes.string,
   meta: PropTypes.arrayOf(PropTypes.object),
+  keywords: PropTypes.arrayOf(PropTypes.string),
   title: PropTypes.string.isRequired,
 }
 


### PR DESCRIPTION
**Purpose**: Being able to pass in custom keywords to SEO Component to make SEO substantially easier down the line.

**Files Changed**: `src/components/seo.js`

**Changes To Other Parts Of Program**: None. All other components, with calls to seo.js, should work as previously defined, but additions can be made down the line.

**Example**: If we want to pop up when Berkeley and Entrepreneurship are mentioned simultaneously, we can pass them into the SEO Component as `keywords` and it should handle everything.