### PR TITLE
Added eslint and formatted repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,53 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 11
+    },
+    "plugins": [
+        "react"
+    ],
+    "settings": {
+        "react": {
+            "createClass": "createReactClass", // Regex for Component Factory to use,
+                                                // default to "createReactClass"
+            "pragma": "React",  // Pragma to use, default to "React"
+            "version": "detect", // React version. "detect" automatically picks the version you have installed.
+                                // You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
+                                // default to latest and warns if missing
+                                // It will default to "detect" in the future
+            "flowVersion": "0.53" // Flow version
+        },
+        "propWrapperFunctions": [
+            // The names of any function used to wrap propTypes, e.g. `forbidExtraProps`. If this isn't set, any propTypes wrapped in a function will be skipped.
+            "forbidExtraProps",
+            {"property": "freeze", "object": "Object"},
+            {"property": "myFavoriteWrapper"}
+        ],
+        "linkComponents": [
+            // Components used as alternatives to <a> for linking, eg. <Link to={ url } />
+            "Hyperlink",
+            {"name": "Link", "linkAttribute": "to"}
+        ]
+    },
+    "rules": {
+        "react/jsx-uses-react": "error",
+        "react/jsx-uses-vars": "error",
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Config
+config.js
+
 # Logs
 logs
 *.log

--- a/functions-src/github.js
+++ b/functions-src/github.js
@@ -60,7 +60,7 @@ function GithubAPI(auth) {
         if (!repo) {
             throw 'Repository is not initialized';
         }
-        if (!currentBranch.hasOwnProperty('name')) {
+        if (!Object.prototype.hasOwnProperty.call(currentBranch, "name")) {
             throw 'Branch is not set';
         }
 
@@ -169,7 +169,7 @@ function GithubAPI(auth) {
     function updateHead() {
         return repo.updateHead('heads/' + currentBranch.name, newCommit.sha);
     }
-};
+}
 
 module.exports = {
     GithubAPI

--- a/functions-src/source-rss.js
+++ b/functions-src/source-rss.js
@@ -2,14 +2,16 @@
 
 // Note that `netlify-lambda` only locally emulates Netlify Functions, while `netlify-identity-widget` interacts with a real Netlify Identity instance. This means that `netlify-lambda` doesn't support Netlify Functions + Netlify Identity integration.
 
-const axios = require("axios");
+// const axios = require("axios");
 var vfile = require('vfile')
-var report = require('vfile-reporter')
+// var report = require('vfile-reporter')
 var unified = require('unified')
 var parseRehype = require('rehype-parse')
 var rehype2remark = require('rehype-remark')
 var stringify = require('remark-stringify')
+const config = require("../config");
 const Parser = require("rss-parser");
+
 const rssParser = new Parser();
 const { GithubAPI } = require("./github");
 
@@ -19,8 +21,8 @@ module.exports.handler = (event, context, callback) => {
     // const { identity, user } = context.clientContext;
 
     let gh = new GithubAPI({
-      username: "",
-      password: ""
+      username: config.username,
+      password: config.password
     });
 
     gh.setRepo('akirillo', 'begin_2.0-jamstack');

--- a/functions-src/token-hider/token-hider.js
+++ b/functions-src/token-hider/token-hider.js
@@ -1,9 +1,10 @@
 const axios = require("axios")
-const qs = require("qs")
+// const qs = require("qs")
 
-exports.handler = async function(event, context) {
+// eslint-disable-next-line no-unused-vars
+exports.handler = async function(_event, _context) {
   // apply our function to the queryStringParameters and assign it to a variable
-  const API_PARAMS = qs.stringify(event.queryStringParameters)
+  // const API_PARAMS = qs.stringify(event.queryStringParameters)
   // Get env var values defined in our Netlify site UI
   // TODO: change this
   const { API_SECRET = "shiba" } = process.env

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "@reach/tabs": "^0.1.6",
     "@reach/visually-hidden": "^0.1.4",
     "axios": "^0.19.2",
+    "babel-eslint": "^10.1.0",
+    "eslint-plugin-react": "^7.20.0",
     "gatsby": "^2.15.11",
     "gatsby-image": "^2.2.17",
     "gatsby-plugin-create-client-paths": "^2.1.6",
@@ -46,6 +48,7 @@
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""
   },
   "devDependencies": {
+    "eslint": "^7.1.0",
     "netlify-lambda": "^1.6.3",
     "prettier": "^1.18.2"
   },

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -1,4 +1,5 @@
 import React from "react"
+import PropTypes from "prop-types"
 import { Router } from "@reach/router"
 import Layout from "../components/layout"
 import NavBar from "./components/NavBar"
@@ -21,8 +22,13 @@ const App = () => {
     </Layout>
   )
 }
+
 function PublicRoute(props) {
   return <div>{props.children}</div>
+}
+
+PublicRoute.propTypes = {
+  children: PropTypes.element.isRequired
 }
 
 export default App

--- a/src/app/components/NavBar.js
+++ b/src/app/components/NavBar.js
@@ -3,7 +3,7 @@ import { Link, navigate } from "gatsby"
 
 import { useIdentityContext } from "react-netlify-identity-widget"
 
-export default () => {
+const NavBar = () => {
   const { user, isLoggedIn, logoutUser } = useIdentityContext()
   let message = isLoggedIn
     ? `Hello, ${user.user_metadata && user.user_metadata.full_name}`
@@ -45,3 +45,5 @@ export default () => {
     </div>
   )
 }
+
+export default NavBar

--- a/src/app/components/PrivateRoute.js
+++ b/src/app/components/PrivateRoute.js
@@ -1,4 +1,5 @@
 import React from "react"
+import PropTypes from "prop-types"
 import { navigate } from "gatsby"
 import { useIdentityContext } from "react-netlify-identity-widget"
 
@@ -16,6 +17,14 @@ function PrivateRoute(props) {
     [isLoggedIn, location]
   )
   return isLoggedIn ? <Component {...rest} /> : null
+}
+
+PrivateRoute.propTypes = {
+  component: PropTypes.element.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string.isRequired
+  }).isRequired,
+
 }
 
 export default PrivateRoute

--- a/src/app/login.js
+++ b/src/app/login.js
@@ -1,14 +1,14 @@
 import React from "react"
-import { navigate } from "gatsby"
+// import { navigate } from "gatsby"
 
 import {
   IdentityModal,
-  useIdentityContext,
+  // useIdentityContext,
 } from "react-netlify-identity-widget"
 import "react-netlify-identity-widget/styles.css" // delete if you want to bring your own CSS
 
 function Login() {
-  const identity = useIdentityContext()
+  // const identity = useIdentityContext()
   const [dialog, setDialog] = React.useState(false)
   return (
     <>
@@ -18,8 +18,8 @@ function Login() {
       <IdentityModal
         showDialog={dialog}
         onCloseDialog={() => setDialog(false)}
-        onLogin={user => navigate("/app/profile")}
-        onSignup={user => navigate("/app/profile")}
+        // onLogin={user => navigate("/app/profile")}
+        // onSignup={user => navigate("/app/profile")}
       />
     </>
   )

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,6 +6,7 @@
  */
 
 import React from "react"
+import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 
 import Header from "./header"
@@ -42,6 +43,10 @@ const Layout = ({ children }) => {
       </div>
     </>
   )
+}
+
+Layout.propTypes = {
+  children: PropTypes.element.isRequired
 }
 
 export default Layout

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,7 +6,14 @@ import Image from "../components/image"
 import SEO from "../components/seo"
 
 class IndexPage extends React.Component {
-  state = { loading: false, msg: null }
+  constructor(props) {
+    super(props);
+
+    this.state = { loading: false, msg: null };
+    
+    this.handleClick = this.handleClick.bind(this);
+  }
+  
   handleClick = e => {
     e.preventDefault()
 
@@ -72,8 +79,8 @@ class IndexPage extends React.Component {
             </ul>
             <hr />
             <p>
-              You can still access Netlify functions even on static "marketing
-              pages". This function is available at{" "}
+              You can still access Netlify functions even on static marketing
+              pages. This function is available at{" "}
               <a href="/.netlify/functions/token-hider">
                 <code>/.netlify/functions/token-hider</code>
               </a>{" "}
@@ -88,7 +95,7 @@ class IndexPage extends React.Component {
             {msg ? (
               <img src={msg[Math.floor(Math.random() * 10)]} alt="dog"></img>
             ) : (
-              <pre>"Click the button and watch this!"</pre>
+              <pre>Click the button and watch this!</pre>
             )}
           </div>
           <div

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,24 @@
+backend:
+  name: 'git-gateway'
+  branch: 'master'
+  commit_messages:
+    create: 'Create {{collection}} “{{slug}}”'
+    update: 'Update {{collection}} “{{slug}}”'
+    delete: 'Delete {{collection}} “{{slug}}”'
+    uploadMedia: '[skip ci] Upload “{{path}}”'
+    deleteMedia: '[skip ci] Delete “{{path}}”'
+
+media_folder: 'static/img'
+public_folder: '/img'
+
+collections:
+  - name: 'rss'
+    label: 'RSS'
+    folder: 'src/data/rss'
+    create: true
+    slug: '{{slug}}-{{year}}-{{month}}-{{day}}'
+    # extension: json // TODO: Test storing/editing JSON content instead of Markdown.
+    fields:
+      - { label: 'Template Key', name: 'templateKey', widget: 'hidden', default: 'rss-post' }
+      - { label: 'Title', name: 'title', widget: 'string' }
+      - { label: 'Body', name: 'body', widget: 'markdown' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3418,6 +3418,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 character-entities-html4@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/character-entities-html4/-/character-entities-html4-1.1.4.tgz#0e64b0a3753ddbf1fdc044c5fd01d0199a02e125"
@@ -4094,6 +4102,15 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
+  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
 crypt@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
@@ -4490,7 +4507,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@~0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
@@ -5304,10 +5321,61 @@ eslint@^6.8.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
+eslint@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.1.0.tgz#d9a1df25e5b7859b0a3d86bb05f0940ab676a851"
+  integrity sha512-DfS3b8iHMK5z/YLSme8K5cge168I8j8o1uiVmFCgnnjxZQbCGyraF8bMl7Ju4yfBmCuxD7shOF7eqGkcuIHfsA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^2.0.0"
+    eslint-visitor-keys "^1.1.0"
+    espree "^7.0.0"
+    esquery "^1.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
 espree@^6.1.2:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
   integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
+
+espree@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.0.0.tgz#8a7a60f218e69f120a842dc24c5a88aa7748a74e"
+  integrity sha512-/r2XEx5Mw4pgKdyb7GNLQNsu++asx/dltf/CI8RFi9oGHxmQFgvLbc5Op4U6i8Oaj+kdslhJtVlEZeAqH5qOTw==
   dependencies:
     acorn "^7.1.1"
     acorn-jsx "^5.2.0"
@@ -5318,7 +5386,7 @@ esprima@^4.0.0, esprima@^4.0.1:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
-esquery@^1.0.1:
+esquery@^1.0.1, esquery@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
   integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
@@ -9141,6 +9209,14 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -10469,6 +10545,18 @@ optionator@^0.8.1, optionator@^0.8.3:
     type-check "~0.3.2"
     word-wrap "~1.2.3"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 ora@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
@@ -11446,6 +11534,11 @@ prebuild-install@^5.3.3:
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -12178,7 +12271,7 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
-regexpp@^3.0.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
@@ -12869,7 +12962,7 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2:
   version "7.3.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
@@ -13732,7 +13825,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@^3.0.1:
+strip-json-comments@^3.0.1, strip-json-comments@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
@@ -14306,6 +14399,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -15106,7 +15206,7 @@ wonka@^4.0.10, wonka@^4.0.9:
   resolved "https://registry.yarnpkg.com/wonka/-/wonka-4.0.13.tgz#8d188160bd5742870c78ede7a4eba686d089a33f"
   integrity sha512-aWg92IVvbP/kp+q9rw+k/Uw3C/S2J0dTDNhEhivGVH3GXJZgpFk2nuyVtiS7Y1d0UG3m4jvOrR7bPXim6D/TBg==
 
-word-wrap@~1.2.3:
+word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==


### PR DESCRIPTION
I added `eslint`, using `eslint-plugin-react` and the `babel-eslint` parser. I also lint-fixed the repo to start us off.

Using ESLint should be pretty straightforward, you just `yarn install`, then run `npx eslint --fix <path>` to auto-fix what's possible and print remaining linter errors to the console.

Also, if you use VSCode, I highly recommend using the [ESLint plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).

Closes #13.