### PR TITLE
Updated source config format

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -37,7 +37,7 @@ collections:
     label: "RSS Source"
     folder: "src/data/rss/sources"
     create: true
-    slug: "{{slug}}-{{id}}"
+    slug: "{{slug}}"
     extension: json
     fields:
       - {
@@ -46,7 +46,6 @@ collections:
           widget: "hidden",
           default: "rss-source",
         }
-      - { label: "ID", name: "id", widget: "string" }
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Url", name: "url", widget: "string" }
 
@@ -76,7 +75,7 @@ collections:
     label: "Facebook Source"
     folder: "src/data/fb/sources"
     create: true
-    slug: "{{slug}}-{{id}}"
+    slug: "{{slug}}"
     extension: json
     fields:
       - {
@@ -85,7 +84,6 @@ collections:
           widget: "hidden",
           default: "fb-source",
         }
-      - { label: "ID", name: "id", widget: "string" }
       - { label: "Title", name: "title", widget: "string" }
       - { label: "Url", name: "url", widget: "string" }
 


### PR DESCRIPTION
Removed `id` field from sources, for now they'll be uniquely identified by their `slugs`.