### PR TITLE
Data source configuration via CMS initialized

### DIFF
--- a/functions-src/source-rss.js
+++ b/functions-src/source-rss.js
@@ -75,17 +75,15 @@ const sourceRSS = (_event, context, callback) => {
           })
         })
 
-        callback(null, {
-          statusCode: 200,
-          body: JSON.stringify(filesToPush),
+        gh.pushFiles(
+          `RSS content push on ${moment().format("YYYY-MM-DD")}`,
+          filesToPush
+        ).then(() => {
+          callback(null, {
+            statusCode: 200,
+            body: JSON.stringify(filesToPush),
+          })
         })
-
-        // gh.pushFiles("Testing JSON usage in CMS", filesToPush).then(() => {
-        //   callback(null, {
-        //     statusCode: 200,
-        //     body: JSON.stringify(filesToPush),
-        //   })
-        // })
       })
       .catch(err => {
         callback(err)


### PR DESCRIPTION
I've set up a basic format for how configuration objects for every data source should be constructed.

At a minimum, each configuration object must have a `sourceKey` property. This is the source's slug/shorthand, used as the `source` field in posts generated from it.

Each collection's source configuration objects should be stored in `src/data/:collection/sources`, e.g. `src/data/rss/sources`.

We can still think about the taxonomy of info here, e.g. RSS a "source" or is the SCET RSS feed a "source" within the RSS "collection?"

For now, it doesn't really matter since we're still iterating quickly.

**IMPORTANT**: We need to think about the specific structure of the source configuration object fro each source/collection. I've set a minimal one up for RSS that contains `sourceKey`, `title`, and `url`, **but we still need to set one up for Facebook, Courses, and potentially IRD**.

Closes #38 
