### PR TITLE
Set up Netlify / local environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.js
 node_modules
 .cache
 public
+.env

--- a/functions-src/github.js
+++ b/functions-src/github.js
@@ -188,6 +188,6 @@ function GithubAPI(auth) {
   }
 }
 
-module.exports = {
-  GithubAPI,
-}
+const gh = new GithubAPI({ token: process.env.GITHUB_TOKEN })
+
+module.exports = gh

--- a/functions-src/source-fb.js
+++ b/functions-src/source-fb.js
@@ -2,13 +2,13 @@
  * @callback netlifyCallback
  */
 
-const config = require("../config")
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
 
-const { GithubAPI } = require("./github")
+const gh = require("./github")
 const { FB } = require("fb")
-FB.setAccessToken(config.apikey)
+// TODO: @Arushi update to make use of .env
+FB.setAccessToken(process.env.FB_KEY)
 
 /**
  * Pulls in FB events, saves it in a JSON, and pushes these JSONs as files to Github, where they are recognized by Netlify CMS.
@@ -19,10 +19,6 @@ FB.setAccessToken(config.apikey)
  */
 const sourceFB = (_event, context, callback) => {
   if (context.clientContext) {
-    let gh = new GithubAPI({
-      token: config.token,
-    })
-
     gh.init()
       .then(() => {
         FB.api(

--- a/functions-src/source-ird.js
+++ b/functions-src/source-ird.js
@@ -2,13 +2,12 @@
  * @callback netlifyCallback
  */
 
-const config = require("../config")
 const _ = require("lodash")
 const axios = require("axios")
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
 
-const { GithubAPI } = require("./github")
+const gh = require("./github")
 
 /**
  * Pulls in resources from the Innovation Resources Database {@link https://innovationresourcedatabase.herokuapp.com/},
@@ -23,15 +22,12 @@ const sourceIRD = (_event, context, callback) => {
   if (context.clientContext) {
     // TODO: Look into using the context object for auth.
     // const { identity, user } = context.clientContext;
-    let gh = new GithubAPI({
-      token: config.gitHubToken,
-    })
 
     gh.init()
       .then(() => {
         axios
           .get(
-            `https://berkeley-innovation-resources.herokuapp.com/resources?api_key=${config.irdApiKey}`
+            `https://berkeley-innovation-resources.herokuapp.com/resources?api_key=${process.env.IRD_KEY}`
           )
           .then(resourcesResponse => {
             const filesToPush = []

--- a/functions-src/source-rss.js
+++ b/functions-src/source-rss.js
@@ -2,13 +2,12 @@
  * @callback netlifyCallback
  */
 
-const config = require("../config")
 const Parser = require("rss-parser")
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
 
 const rssParser = new Parser()
-const { GithubAPI } = require("./github")
+const gh = require("./github")
 
 /**
  * Pulls in RSS content, saves the source, id, title, url, author, excerpt, and date of each item in a JSON, and pushes
@@ -20,11 +19,9 @@ const { GithubAPI } = require("./github")
  */
 const sourceRSS = (_event, context, callback) => {
   if (context.clientContext) {
+    console.log(process.env)
     // TODO: Look into using the context object for auth.
     // const { identity, user } = context.clientContext;
-    let gh = new GithubAPI({
-      token: config.gitHubToken,
-    })
 
     gh.init()
       .then(() => {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@reach/visually-hidden": "^0.1.4",
     "axios": "^0.19.2",
     "babel-eslint": "^10.1.0",
+    "dotenv": "^8.2.0",
     "eslint-plugin-react": "^7.20.0",
     "fb": "^2.0.0",
     "gatsby": "^2.15.11",
@@ -45,7 +46,10 @@
     "test": "echo \"Write tests! -> https://gatsby.app/unit-testing\""
   },
   "lint-staged": {
-    "*.{js, jsx, json, md}": ["eslint --fix", "prettier --write"]
+    "*.{js, jsx, json, md}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This addresses #10, but does not close it.

Very simply, I added a (local, `.gitignored`) `.env` file that contains the environment variables `GITHUB_TOKEN` and `IRD_KEY`. The same environment variables are mirrored in our Netlify management dashboard.

We now use `process.env` instead of `config`, the developer experience is pretty much the same.

@somaniarushi, make sure to update update the environment variables with an API key for Facebook (I have a placeholder titled `FB_KEY` in the code)