### PR TITLE
JWT Auth Layer for Netlify Functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .cache
 public
 .env
+functions-src/test.js

--- a/functions-src/source-fb.js
+++ b/functions-src/source-fb.js
@@ -4,6 +4,7 @@
 
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
+const jwt = require("jsonwebtoken")
 
 const gh = require("./github")
 const { FB } = require("fb")
@@ -17,66 +18,71 @@ FB.setAccessToken(process.env.FB_KEY)
  * @param {Object} context: Provided by Netlify if Identity is enabled, contains a `clientContext` object with `identity` and `user` properties.
  * @param {netlifyCallback} callback: Defined like callback in an AWS Lambda function, used to return either an error, or a response object.
  */
-const sourceFB = (_event, context, callback) => {
-  if (context.clientContext) {
-    gh.init()
-      .then(() => {
-        FB.api(
-          "",
-          "post",
-          {
-            batch: [
-              { method: "get", relative_url: "/me/events" },
-              { method: "get", relative_url: "/techvista18/events" },
-            ],
-          },
-          function(response) {
-            const filesToPush = []
+const sourceFB = (_event, _context, callback) => {
+  const token = event.headers.Authorization.replace(/Bearer/i, "").trim()
+  jwt.verify(token, process.env.JWT_SECRET, error => {
+    if (!error) {
+      gh.init()
+        .then(() => {
+          FB.api(
+            "",
+            "post",
+            {
+              batch: [
+                { method: "get", relative_url: "/me/events" },
+                { method: "get", relative_url: "/techvista18/events" },
+              ],
+            },
+            function(response) {
+              const filesToPush = []
 
-            response.forEach(item => {
-              const file = JSON.parse(item.body)
-              file.data.forEach(event => {
-                const date = moment(event.start_time).format("YYYY-MM-DD")
-                const id = uuidv4()
+              response.forEach(item => {
+                const file = JSON.parse(item.body)
+                file.data.forEach(event => {
+                  const date = moment(event.start_time).format("YYYY-MM-DD")
+                  const id = uuidv4()
 
-                filesToPush.push({
-                  content: JSON.stringify({
-                    templateKey: "fb-post",
-                    id,
-                    source: "fb",
-                    title: event.name,
-                    url: `facebook.com/${event.id}`,
-                    page: "test page",
-                    description: event.description,
-                    date,
-                    location: Object.prototype.hasOwnProperty.call(
-                      event,
-                      "place"
-                    )
-                      ? event.place.name
-                      : "",
-                  }),
-                  path: `src/data/fb/fb-${date}-${id}.json`,
+                  filesToPush.push({
+                    content: JSON.stringify({
+                      templateKey: "fb-post",
+                      id,
+                      source: "fb",
+                      title: event.name,
+                      url: `facebook.com/${event.id}`,
+                      page: "test page",
+                      description: event.description,
+                      date,
+                      location: Object.prototype.hasOwnProperty.call(
+                        event,
+                        "place"
+                      )
+                        ? event.place.name
+                        : "",
+                    }),
+                    path: `src/data/fb/fb-${date}-${id}.json`,
+                  })
                 })
               })
-            })
 
-            gh.pushFiles(
-              `FB-JSON storage in CMS on ${Date()}`,
-              filesToPush
-            ).then(() => {
-              callback(null, {
-                statusCode: 200,
-                body: JSON.stringify(filesToPush),
+              gh.pushFiles(
+                `FB-JSON storage in CMS on ${Date()}`,
+                filesToPush
+              ).then(() => {
+                callback(null, {
+                  statusCode: 200,
+                  body: JSON.stringify(filesToPush),
+                })
               })
-            })
-          }
-        )
-      })
-      .catch(err => {
-        callback(err)
-      })
-  }
+            }
+          )
+        })
+        .catch(err => {
+          callback(err)
+        })
+    } else {
+      console.log(error)
+    }
+  })
 }
 
 module.exports.handler = sourceFB

--- a/functions-src/source-ird.js
+++ b/functions-src/source-ird.js
@@ -6,6 +6,7 @@ const _ = require("lodash")
 const axios = require("axios")
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
+const jwt = require("jsonwebtoken")
 
 const gh = require("./github")
 
@@ -18,69 +19,71 @@ const gh = require("./github")
  * @param {Object} context: Provided by Netlify if Identity is enabled, contains a `clientContext` object with `identity` and `user` properties.
  * @param {netlifyCallback} callback: Defined like callback in an AWS Lambda function, used to return either an error, or a response object.
  */
-const sourceIRD = (_event, context, callback) => {
-  if (context.clientContext) {
-    // TODO: Look into using the context object for auth.
-    // const { identity, user } = context.clientContext;
+const sourceIRD = (_event, _context, callback) => {
+  const token = event.headers.Authorization.replace(/Bearer/i, "").trim()
+  jwt.verify(token, process.env.JWT_SECRET, error => {
+    if (!error) {
+      gh.init()
+        .then(() => {
+          axios
+            .get(
+              `https://berkeley-innovation-resources.herokuapp.com/resources?api_key=${process.env.IRD_KEY}`
+            )
+            .then(resourcesResponse => {
+              const filesToPush = []
+              const tagFields = [
+                "types",
+                "audiences",
+                "population_focuses",
+                "availabilities",
+                "innovation_stages",
+                "topics",
+                "technologies",
+              ]
 
-    gh.init()
-      .then(() => {
-        axios
-          .get(
-            `https://berkeley-innovation-resources.herokuapp.com/resources?api_key=${process.env.IRD_KEY}`
-          )
-          .then(resourcesResponse => {
-            const filesToPush = []
-            const tagFields = [
-              "types",
-              "audiences",
-              "population_focuses",
-              "availabilities",
-              "innovation_stages",
-              "topics",
-              "technologies",
-            ]
-
-            resourcesResponse.data.forEach(resource => {
-              const id = uuidv4()
-              const date = moment().format("YYYY-MM-DD")
-              const tags = _.flatMap(tagFields, field =>
-                _.map(
-                  _.filter(resource[field], tag => tag.val),
-                  tag => tag.val
+              resourcesResponse.data.forEach(resource => {
+                const id = uuidv4()
+                const date = moment().format("YYYY-MM-DD")
+                const tags = _.flatMap(tagFields, field =>
+                  _.map(
+                    _.filter(resource[field], tag => tag.val),
+                    tag => tag.val
+                  )
                 )
-              )
 
-              filesToPush.push({
-                content: JSON.stringify({
-                  templateKey: "ird-resource",
-                  source: "ird",
-                  id,
-                  tags,
-                  title: resource.title,
-                  url: resource.url,
-                  description: resource.desc,
-                  date,
-                }),
-                path: `src/data/ird/ird-${date}-${id}.json`,
+                filesToPush.push({
+                  content: JSON.stringify({
+                    templateKey: "ird-resource",
+                    source: "ird",
+                    id,
+                    tags,
+                    title: resource.title,
+                    url: resource.url,
+                    description: resource.desc,
+                    date,
+                  }),
+                  path: `src/data/ird/ird-${date}-${id}.json`,
+                })
+              })
+
+              gh.pushFiles(
+                "Testing IRD content pushing to the proper folder with id",
+                filesToPush
+              ).then(() => {
+                callback(null, {
+                  statusCode: 200,
+                  body: JSON.stringify(filesToPush),
+                })
               })
             })
-
-            gh.pushFiles(
-              "Testing IRD content pushing to the proper folder with id",
-              filesToPush
-            ).then(() => {
-              callback(null, {
-                statusCode: 200,
-                body: JSON.stringify(filesToPush),
-              })
-            })
-          })
-      })
-      .catch(err => {
-        callback(err)
-      })
-  }
+        })
+        .catch(err => {
+          callback(err)
+        })
+    } else {
+      console.log(error)
+    }
+  })
 }
 
 module.exports.handler = sourceIRD

--- a/functions-src/source-rss.js
+++ b/functions-src/source-rss.js
@@ -5,6 +5,7 @@
 const Parser = require("rss-parser")
 const moment = require("moment")
 const { v4: uuidv4 } = require("uuid")
+const jwt = require("jsonwebtoken")
 
 const rssParser = new Parser()
 const gh = require("./github")
@@ -17,75 +18,76 @@ const gh = require("./github")
  * @param {Object} context: Provided by Netlify if Identity is enabled, contains a `clientContext` object with `identity` and `user` properties.
  * @param {netlifyCallback} callback: Defined like callback in an AWS Lambda function, used to return either an error, or a response object.
  */
-const sourceRSS = (_event, context, callback) => {
-  if (context.clientContext) {
-    console.log(process.env)
-    // TODO: Look into using the context object for auth.
-    // const { identity, user } = context.clientContext;
+const sourceRSS = (event, _context, callback) => {
+  const token = event.headers.Authorization.replace(/Bearer/i, "").trim()
+  jwt.verify(token, process.env.JWT_SECRET, error => {
+    if (!error) {
+      gh.init()
+        .then(() => {
+          return gh.getSources("rss")
+        })
+        .then(sources => {
+          const feedPromises = []
 
-    gh.init()
-      .then(() => {
-        return gh.getSources("rss")
-      })
-      .then(sources => {
-        const feedPromises = []
+          sources.forEach(source => {
+            feedPromises.push({
+              promise: rssParser.parseURL(source.url),
+              source: source.sourceKey,
+            })
+          })
 
-        sources.forEach(source => {
-          feedPromises.push({
-            promise: rssParser.parseURL(source.url),
-            source: source.sourceKey,
+          return Promise.all(
+            feedPromises.map(feedPromise => feedPromise.promise)
+          ).then(feeds => {
+            return feeds.map((feed, i) => ({
+              feed,
+              source: sources[i].sourceKey,
+            }))
           })
         })
+        .then(feeds => {
+          const filesToPush = []
 
-        return Promise.all(
-          feedPromises.map(feedPromise => feedPromise.promise)
-        ).then(feeds => {
-          return feeds.map((feed, i) => ({
-            feed,
-            source: sources[i].sourceKey,
-          }))
-        })
-      })
-      .then(feeds => {
-        const filesToPush = []
+          feeds.forEach(feedObj => {
+            const { feed } = feedObj
+            const { source } = feedObj
+            feed.items.forEach(item => {
+              const date = moment(item.isoDate).format("YYYY-MM-DD")
+              const id = uuidv4()
 
-        feeds.forEach(feedObj => {
-          const { feed } = feedObj
-          const { source } = feedObj
-          feed.items.forEach(item => {
-            const date = moment(item.isoDate).format("YYYY-MM-DD")
-            const id = uuidv4()
+              filesToPush.push({
+                content: JSON.stringify({
+                  templateKey: "rss-post",
+                  id,
+                  source,
+                  title: item.title,
+                  url: item.guid,
+                  author: item.creator,
+                  excerpt: item.contentSnippet,
+                  date,
+                }),
+                path: `src/data/rss/${source}-${date}-${id}.json`,
+              })
+            })
+          })
 
-            filesToPush.push({
-              content: JSON.stringify({
-                templateKey: "rss-post",
-                id,
-                source,
-                title: item.title,
-                url: item.guid,
-                author: item.creator,
-                excerpt: item.contentSnippet,
-                date,
-              }),
-              path: `src/data/rss/${source}-${date}-${id}.json`,
+          gh.pushFiles(
+            `RSS content push on ${moment().format("YYYY-MM-DD")}`,
+            filesToPush
+          ).then(() => {
+            callback(null, {
+              statusCode: 200,
+              body: JSON.stringify(filesToPush),
             })
           })
         })
-
-        gh.pushFiles(
-          `RSS content push on ${moment().format("YYYY-MM-DD")}`,
-          filesToPush
-        ).then(() => {
-          callback(null, {
-            statusCode: 200,
-            body: JSON.stringify(filesToPush),
-          })
+        .catch(err => {
+          callback(err)
         })
-      })
-      .catch(err => {
-        callback(err)
-      })
-  }
+    } else {
+      console.log(error)
+    }
+  })
 }
 
 module.exports.handler = sourceRSS

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "gatsby-transformer-json": "^2.4.5",
     "gatsby-transformer-sharp": "^2.2.13",
     "github-api": "^3.3.0",
+    "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.15",
     "moment": "^2.26.0",
     "netlify-cms-app": "^2.12.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3477,6 +3477,11 @@ buffer-crc32@~0.2.3:
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
   integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
 buffer-equal@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-0.0.1.tgz#91bc74b11ea405bc916bc6aa908faafa5b4aac4b"
@@ -5408,6 +5413,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -9895,6 +9907,22 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -9912,6 +9940,23 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
   dependencies:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 jwt-decode@^2.1.0, jwt-decode@^2.2.0:
   version "2.2.0"
@@ -10236,10 +10281,40 @@ lodash.has@^4.0:
   resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
   integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
   integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
@@ -10260,6 +10335,11 @@ lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
Closes #9.

I looked into using Netlify Identity to authenticate requests made to our Netlify Functions endpoints, since an identity `context` object is already included in the function signature.

However, this context object is only included in client requests from logged-in Identity users, not from a server environment, like where our cron job will be (on a paid Netlify plan, we could just retrieve JWTs from our Identity instance, but alas).

Instead, we'll just use JWT tokens with an agreed-upon secret that is set in our local `.envs` and in our Netlify environment variables.
